### PR TITLE
Specify mpioperator/mpi-operator's tag explicitly

### DIFF
--- a/blog-post-sample/README.md
+++ b/blog-post-sample/README.md
@@ -82,7 +82,7 @@ In order to leverage this, `ksonnet` is required in your OS, please follow [kson
 ➜ ks pkg install kubeflow/mpi-job@master
 
 # Generate Manifests
-➜ ks generate mpi-operator mpi-operator
+➜ ks prototype use mpi-operator --name=mpi-operator --image=mpioperator/mpi-operator:0.1.0 mpi-operator
 
 # Deploy
 ➜ ks apply default -c mpi-operator


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*

The Ksonnet package is specifying mpioperator/mpi-operator:latest as
its container image by default.
However the latest version, 0.2.1 is not compatible with the rest of
the package (e.g. it doesn’t have –gpus-per-node)

https://github.com/kubeflow/kubeflow/issues/3715

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
